### PR TITLE
Add Py_TYPE fallback for python <3.9

### DIFF
--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -729,6 +729,10 @@ init_pysha3(void)
     }
 #endif
 
+#if PY_VERSION_HEX < 0x030900A4
+#define Py_SET_TYPE(type, value)      \
+    Py_TYPE(type) = value
+#endif
 #define init_sha3type(name, type)     \
     do {                              \
         Py_SET_TYPE(type, &PyType_Type); \


### PR DESCRIPTION
I’m interested in re-adding support for python<3.9 to this project. I found the check used here from https://github.com/swig/swig/pull/2116/files .

This is for https://github.com/ctrl-Felix/mospy/pull/14 .

I’m editing on the web, so have not verified this change by running the code, and may likely have made a typo.