### PR TITLE
Modernize release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ install:
 dist: clean sdist manylinux1
 
 sdist: README.html README.md
-	$(PYTHON) setup.py sdist --formats gztar,zip
+	$(PYTHON) -m build
 
 manylinux1: clean
 	docker run --rm -v $(CURDIR):/io:Z \

--- a/setup.py
+++ b/setup.py
@@ -121,9 +121,9 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Topic :: Security :: Cryptography",
     ],
-    command_options={
-        'sdist': {
-            'formats': ('setup.py', 'zip,gztar'),
+    options={
+        "sdist": {
+            "formats": ["gztar", "zip"],
         },
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -121,4 +121,9 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Topic :: Security :: Cryptography",
     ],
+    command_options={
+        'sdist': {
+            'formats': ('setup.py', 'zip,gztar'),
+        },
+    },
 )


### PR DESCRIPTION
We should maybe consider seeing if we can get this to build modern python versions too, but here is a bandaid fix to get past the deprecation warning mentioned [here](https://github.com/ethereum/eth-hash/issues/62). 

The docker commands weren't working locally for me, so it's probably worth a check to make sure they aren't broken before this gets merged.